### PR TITLE
Active decks refill when empty now

### DIFF
--- a/scripts/CombatScripts/attack.gd
+++ b/scripts/CombatScripts/attack.gd
@@ -45,10 +45,12 @@ func _on_plan_button_pressed():
 	transition_to_planning_phase()
 
 func transition_to_planning_phase():
+
 	self.visible = false
 	
 	var planning_scene = get_parent().get_node("Planning_Phase")
 	planning_scene.visible = true
+	planning_scene.refill_active_deck()
 	planning_scene.display_deck()
 	planning_scene.display_prepared_hand()
 
@@ -118,8 +120,3 @@ func next_turn():
 	if player.hand.size() == 0 and enemy.hand.size() == 0:
 		print("Both parties have no cards left in their hand!")
 		return "end"
-	
-
-
-
-	#print("Next turn executed.")

--- a/scripts/CombatScripts/enemy.gd
+++ b/scripts/CombatScripts/enemy.gd
@@ -45,7 +45,7 @@ func prepare_hand() -> void:
 	elif active_deck.size() <= 7:
 		print("enemy deck is less than 7 long, using rest of deck as hand")
 		hand = active_deck.duplicate()
-		print("enemy hand after taking rest of the deck is", hand.size(), " long.")
+		print("enemy hand after taking rest of the deck is ", hand.size(), " long.")
 		active_deck.clear()
 
 func _ready():

--- a/scripts/CombatScripts/enemyGeneration.gd
+++ b/scripts/CombatScripts/enemyGeneration.gd
@@ -4,7 +4,7 @@ class_name enemyGeneration
 
 var areas: Dictionary = {
 	"Forest": [
-		{"name": "Goblin", "health": 5, "deck": [
+		{"name": "Goblin", "health": 25, "deck": [
 			BapCard.new(),
 			BlankCard.new("Card 2", "Effect", "Clause", "Type", "Sprite", 4, 10, []),
 			BlankCard.new("Card 3", "Effect", "Clause", "Type", "Sprite", 1, 10, []),
@@ -14,7 +14,7 @@ var areas: Dictionary = {
 			BlankCard.new("Card 7", "Effect", "Clause", "Type", "Sprite", 1, 10, []),
 			BlankCard.new("Card 8", "Effect", "Clause", "Type", "Sprite", 1, 10, [])
 		]},
-		{"name": "Orc", "health": 5, "deck": [
+		{"name": "Orc", "health": 25, "deck": [
 			BlankCard.new("Card 9", "Effect", "Clause", "Type", "Sprite", 1, 10, []),
 			BlankCard.new("Card 10", "Effect", "Clause", "Type", "Sprite", 2, 10, []),
 			BlankCard.new("Card 11", "Effect", "Clause", "Type", "Sprite", 1, 10, []),

--- a/scripts/CombatScripts/planning.gd
+++ b/scripts/CombatScripts/planning.gd
@@ -89,3 +89,9 @@ func transition_to_attack_phase():
 	attack_scene.visible = true
 	enemy.prepare_hand()
 	attack_scene.transition_to_attack_phase()
+
+func refill_active_deck():
+	if player.active_deck.size() == 0:
+		player.active_deck = player.deck.duplicate()
+	if enemy.active_deck.size() == 0:
+		enemy.active_deck = enemy.deck.duplicate()

--- a/scripts/main.gd
+++ b/scripts/main.gd
@@ -4,7 +4,7 @@ var player_instance = Player
 
 func _ready():
 	player_instance = get_node("Player")
-	player_instance.initialize("JosiePosie", 10)
+	player_instance.initialize("JosiePosie", 20)
 	player_instance._create_test_deck()
 	#player_instance.copy_deck()
 	


### PR DESCRIPTION
resolves #29 

Now when we go from the attack phase to the planning phase, we check if each active decks are empty, and if they are, we recopy the deck to the active deck.
