### PR TITLE
47 card tootltips

### DIFF
--- a/assets/fonts/Basic Font Theme.tres
+++ b/assets/fonts/Basic Font Theme.tres
@@ -1,0 +1,6 @@
+[gd_resource type="Theme" load_steps=2 format=3 uid="uid://c6mqy5npqrkqv"]
+
+[ext_resource type="FontFile" uid="uid://sxw0026qgsl6" path="res://assets/fonts/m3x6.ttf" id="1_aruy8"]
+
+[resource]
+default_font = ExtResource("1_aruy8")

--- a/scenes/assets/CardDisplay.tscn
+++ b/scenes/assets/CardDisplay.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=5 format=3 uid="uid://decgll2ts6lvo"]
+[gd_scene load_steps=6 format=3 uid="uid://decgll2ts6lvo"]
 
 [ext_resource type="Script" path="res://scripts/Cards/Classes/card_display.gd" id="1_si5s5"]
 [ext_resource type="Texture2D" uid="uid://cgs88vqvu5f31" path="res://assets/Card/TCOYSCard.png" id="2_si5s5"]
 [ext_resource type="FontFile" uid="uid://sxw0026qgsl6" path="res://assets/fonts/m3x6.ttf" id="3_8adb7"]
+[ext_resource type="PackedScene" uid="uid://ckl3ocaltnpgq" path="res://scenes/assets/CardTooltip.tscn" id="4_xqi2g"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_jrety"]
 size = Vector2(32, 50)
@@ -45,3 +46,6 @@ offset_right = 15.0
 offset_bottom = 24.0
 theme_override_fonts/font = ExtResource("3_8adb7")
 theme_override_font_sizes/font_size = 28
+
+[node name="CardTooltip" parent="." instance=ExtResource("4_xqi2g")]
+position = Vector2(36, -38)

--- a/scenes/assets/CardDisplay.tscn
+++ b/scenes/assets/CardDisplay.tscn
@@ -48,4 +48,5 @@ theme_override_fonts/font = ExtResource("3_8adb7")
 theme_override_font_sizes/font_size = 28
 
 [node name="CardTooltip" parent="." instance=ExtResource("4_xqi2g")]
+visible = false
 position = Vector2(36, -38)

--- a/scenes/assets/CardDisplay.tscn
+++ b/scenes/assets/CardDisplay.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="Script" path="res://scripts/Cards/Classes/card_display.gd" id="1_si5s5"]
 [ext_resource type="Texture2D" uid="uid://cgs88vqvu5f31" path="res://assets/Card/TCOYSCard.png" id="2_si5s5"]
 [ext_resource type="FontFile" uid="uid://sxw0026qgsl6" path="res://assets/fonts/m3x6.ttf" id="3_8adb7"]
-[ext_resource type="PackedScene" uid="uid://ckl3ocaltnpgq" path="res://scenes/assets/CardTooltip.tscn" id="4_xqi2g"]
+[ext_resource type="PackedScene" uid="uid://b3exk7ojml64y" path="res://scenes/assets/CardTooltip.tscn" id="4_xqi2g"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_jrety"]
 size = Vector2(32, 50)

--- a/scenes/assets/CardTooltip.tscn
+++ b/scenes/assets/CardTooltip.tscn
@@ -1,0 +1,35 @@
+[gd_scene load_steps=3 format=3 uid="uid://ckl3ocaltnpgq"]
+
+[ext_resource type="FontFile" uid="uid://sxw0026qgsl6" path="res://assets/fonts/m3x6.ttf" id="1_n7c4v"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_fmwi6"]
+size = Vector2(64.5, 110)
+
+[node name="CardTooltip" type="Node2D"]
+visible = false
+
+[node name="Node2D" type="Node2D" parent="."]
+
+[node name="Area2D" type="Area2D" parent="Node2D"]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Node2D/Area2D"]
+shape = SubResource("RectangleShape2D_fmwi6")
+debug_color = Color(0.961606, 0, 0.509387, 0.42)
+
+[node name="Label" type="Label" parent="Node2D/Area2D/CollisionShape2D"]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -32.0
+offset_top = -54.0
+offset_right = 32.0
+offset_bottom = 56.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_fonts/font = ExtResource("1_n7c4v")
+theme_override_font_sizes/font_size = 47
+text = "lmao"
+horizontal_alignment = 1
+vertical_alignment = 1

--- a/scenes/assets/CardTooltip.tscn
+++ b/scenes/assets/CardTooltip.tscn
@@ -1,22 +1,27 @@
-[gd_scene load_steps=3 format=3 uid="uid://ckl3ocaltnpgq"]
+[gd_scene load_steps=5 format=3 uid="uid://ckl3ocaltnpgq"]
 
+[ext_resource type="Texture2D" uid="uid://cgs88vqvu5f31" path="res://assets/Card/TCOYSCard.png" id="1_k11na"]
 [ext_resource type="FontFile" uid="uid://sxw0026qgsl6" path="res://assets/fonts/m3x6.ttf" id="1_n7c4v"]
+[ext_resource type="Script" path="res://scripts/Cards/Classes/card_tooltip.gd" id="1_nq4fd"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_fmwi6"]
-size = Vector2(64.5, 110)
+size = Vector2(64.5, 100)
 
 [node name="CardTooltip" type="Node2D"]
-visible = false
+script = ExtResource("1_nq4fd")
 
-[node name="Node2D" type="Node2D" parent="."]
+[node name="TcoysCard" type="Sprite2D" parent="."]
+scale = Vector2(1.5, 1.5)
+texture = ExtResource("1_k11na")
 
-[node name="Area2D" type="Area2D" parent="Node2D"]
+[node name="Area2D" type="Area2D" parent="TcoysCard"]
+scale = Vector2(0.5, 0.5)
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Node2D/Area2D"]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="TcoysCard/Area2D"]
 shape = SubResource("RectangleShape2D_fmwi6")
 debug_color = Color(0.961606, 0, 0.509387, 0.42)
 
-[node name="Label" type="Label" parent="Node2D/Area2D/CollisionShape2D"]
+[node name="Label" type="Label" parent="TcoysCard/Area2D/CollisionShape2D"]
 anchors_preset = 8
 anchor_left = 0.5
 anchor_top = 0.5

--- a/scenes/assets/CardTooltip.tscn
+++ b/scenes/assets/CardTooltip.tscn
@@ -1,8 +1,8 @@
-[gd_scene load_steps=5 format=3 uid="uid://ckl3ocaltnpgq"]
+[gd_scene load_steps=5 format=3 uid="uid://b3exk7ojml64y"]
 
 [ext_resource type="Texture2D" uid="uid://cgs88vqvu5f31" path="res://assets/Card/TCOYSCard.png" id="1_k11na"]
-[ext_resource type="FontFile" uid="uid://sxw0026qgsl6" path="res://assets/fonts/m3x6.ttf" id="1_n7c4v"]
 [ext_resource type="Script" path="res://scripts/Cards/Classes/card_tooltip.gd" id="1_nq4fd"]
+[ext_resource type="Theme" uid="uid://c6mqy5npqrkqv" path="res://assets/fonts/Basic Font Theme.tres" id="3_4q3x7"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_fmwi6"]
 size = Vector2(64.5, 100)
@@ -10,31 +10,44 @@ size = Vector2(64.5, 100)
 [node name="CardTooltip" type="Node2D"]
 script = ExtResource("1_nq4fd")
 
-[node name="TcoysCard" type="Sprite2D" parent="."]
+[node name="Card" type="Sprite2D" parent="."]
 scale = Vector2(1.5, 1.5)
 texture = ExtResource("1_k11na")
 
-[node name="Area2D" type="Area2D" parent="TcoysCard"]
+[node name="Area2D" type="Area2D" parent="Card"]
 scale = Vector2(0.5, 0.5)
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="TcoysCard/Area2D"]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Card/Area2D"]
 shape = SubResource("RectangleShape2D_fmwi6")
 debug_color = Color(0.961606, 0, 0.509387, 0.42)
 
-[node name="Label" type="Label" parent="TcoysCard/Area2D/CollisionShape2D"]
+[node name="Damage" type="Label" parent="Card"]
 anchors_preset = 8
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
-offset_left = -32.0
-offset_top = -54.0
-offset_right = 32.0
-offset_bottom = 56.0
+offset_left = -29.0
+offset_top = -24.0
+offset_right = -3.0
+offset_bottom = -11.0
 grow_horizontal = 2
 grow_vertical = 2
-theme_override_fonts/font = ExtResource("1_n7c4v")
-theme_override_font_sizes/font_size = 47
-text = "lmao"
+theme = ExtResource("3_4q3x7")
+theme_override_colors/font_color = Color(0.62833, 0.345557, 1, 1)
+text = "DMG"
 horizontal_alignment = 1
-vertical_alignment = 1
+
+[node name="Name" type="Label" parent="Card"]
+offset_left = -14.6667
+offset_top = -22.6667
+offset_right = 35.3333
+offset_bottom = -2.66667
+scale = Vector2(0.605, 0.605)
+theme = ExtResource("3_4q3x7")
+theme_override_colors/font_color = Color(0.62833, 0.345557, 1, 1)
+theme_override_constants/line_spacing = -5
+text = "Card1 lmao"
+horizontal_alignment = 1
+autowrap_mode = 3
+uppercase = true

--- a/scripts/Cards/Classes/card.gd
+++ b/scripts/Cards/Classes/card.gd
@@ -1,6 +1,4 @@
-#Card.gd
-
-extends Node
+extends Node2D
 
 class_name Card
 

--- a/scripts/Cards/Classes/card_display.gd
+++ b/scripts/Cards/Classes/card_display.gd
@@ -5,12 +5,15 @@ class_name CardDisplay
 signal card_clicked(card, parent_node)
 
 var card: Card
+var hoverable: bool
 
 func _ready():
 	var area = $Area2D
 	if area == null:
 		pass
 	else:
+		area.connect("mouse_entered", Callable(self, "_on_mouse_entered"))
+		area.connect("mouse_exited", Callable(self, "_on_mouse_exited"))
 		area.connect("input_event", Callable(self, "_on_area_input_event"))
 	
 	var name_label = $NameLabel
@@ -22,3 +25,13 @@ func _ready():
 func _on_area_input_event(viewport, event, shape_idx):
 	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
 		emit_signal("card_clicked", card, get_parent())
+
+func _on_mouse_entered():
+	if hoverable:
+		scale = Vector2(scale[0] * 1.2, scale[1] * 1.2)
+		z_index = 100
+
+func _on_mouse_exited():
+	if hoverable:
+		scale = Vector2(scale[0] * (1/1.2), scale[1] * (1/1.2))
+		z_index = 0

--- a/scripts/Cards/Classes/card_display.gd
+++ b/scripts/Cards/Classes/card_display.gd
@@ -9,6 +9,8 @@ var hoverable: bool
 static var current_hovered_card: CardDisplay = null
 var is_mouse_pressed: bool = false
 
+@onready var card_tooltip = $CardTooltip
+
 func _ready():
 	var area = $Area2D
 	if area == null:
@@ -23,6 +25,8 @@ func _ready():
 	
 	var damage_label = $DamageLabel
 	damage_label.text = str(card.damage)
+
+	#_reset_hover_state()
 
 func _process(delta):
 	if current_hovered_card != null and not current_hovered_card.hoverable:
@@ -42,6 +46,7 @@ func _on_mouse_entered():
 		if current_hovered_card != null and current_hovered_card != self:
 			current_hovered_card._reset_hover_state()
 		current_hovered_card = self
+		card_tooltip.show_tooltip()
 		scale = Vector2(scale[0] * 1.2, scale[1] * 1.2)
 		z_index = 100
 
@@ -51,5 +56,6 @@ func _on_mouse_exited():
 
 func _reset_hover_state():
 	current_hovered_card = null
+	card_tooltip.hide_tooltip()
 	scale = Vector2(scale[0] * (1/1.2), scale[1] * (1/1.2))
 	z_index = 0

--- a/scripts/Cards/Classes/card_display.gd
+++ b/scripts/Cards/Classes/card_display.gd
@@ -46,7 +46,7 @@ func _on_mouse_entered():
 		if current_hovered_card != null and current_hovered_card != self:
 			current_hovered_card._reset_hover_state()
 		current_hovered_card = self
-		card_tooltip.show_tooltip()
+		card_tooltip.show_tooltip()  # Ensure tooltip is shown
 		scale = Vector2(scale[0] * 1.2, scale[1] * 1.2)
 		z_index = 100
 
@@ -55,7 +55,8 @@ func _on_mouse_exited():
 		_reset_hover_state()
 
 func _reset_hover_state():
+	if current_hovered_card == self:
+		card_tooltip.hide_tooltip()  # Ensure tooltip is hidden
 	current_hovered_card = null
-	card_tooltip.hide_tooltip()
 	scale = Vector2(scale[0] * (1/1.2), scale[1] * (1/1.2))
 	z_index = 0

--- a/scripts/Cards/Classes/card_display.gd
+++ b/scripts/Cards/Classes/card_display.gd
@@ -6,6 +6,8 @@ signal card_clicked(card, parent_node)
 
 var card: Card
 var hoverable: bool
+static var current_hovered_card: CardDisplay = null
+var is_mouse_pressed: bool = false
 
 func _ready():
 	var area = $Area2D
@@ -22,16 +24,32 @@ func _ready():
 	var damage_label = $DamageLabel
 	damage_label.text = str(card.damage)
 
+func _process(delta):
+	if current_hovered_card != null and not current_hovered_card.hoverable:
+		# Reset hover state if the current hovered card is no longer hoverable
+		current_hovered_card._reset_hover_state()
+
 func _on_area_input_event(viewport, event, shape_idx):
-	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
-		emit_signal("card_clicked", card, get_parent())
+	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT:
+		if event.pressed:
+			is_mouse_pressed = true
+		elif not event.pressed and is_mouse_pressed:
+			is_mouse_pressed = false
+			emit_signal("card_clicked", card, get_parent())
 
 func _on_mouse_entered():
 	if hoverable:
+		if current_hovered_card != null and current_hovered_card != self:
+			current_hovered_card._reset_hover_state()
+		current_hovered_card = self
 		scale = Vector2(scale[0] * 1.2, scale[1] * 1.2)
 		z_index = 100
 
 func _on_mouse_exited():
-	if hoverable:
-		scale = Vector2(scale[0] * (1/1.2), scale[1] * (1/1.2))
-		z_index = 0
+	if hoverable and current_hovered_card == self:
+		_reset_hover_state()
+
+func _reset_hover_state():
+	current_hovered_card = null
+	scale = Vector2(scale[0] * (1/1.2), scale[1] * (1/1.2))
+	z_index = 0

--- a/scripts/Cards/Classes/card_tooltip.gd
+++ b/scripts/Cards/Classes/card_tooltip.gd
@@ -1,0 +1,14 @@
+extends Node2D
+
+@onready var cardDisplay = get_parent()
+
+func _ready() -> void:
+	self.scale = Vector2(1, 1)
+
+func show_tooltip():
+	self.visible = true
+	scale = Vector2(1,1) / Vector2(cardDisplay.scale[0], cardDisplay.scale[1])
+
+
+func hide_tooltip():
+	self.visible = false

--- a/scripts/Cards/Classes/card_tooltip.gd
+++ b/scripts/Cards/Classes/card_tooltip.gd
@@ -1,14 +1,22 @@
 extends Node2D
 
 @onready var cardDisplay = get_parent()
+var target_scale = Vector2(0, 0)
+var scale_speed = 20.0
 
 func _ready() -> void:
-	self.scale = Vector2(1, 1)
+	self.scale = Vector2(0, 0)  # Start hidden
+
+func _process(delta: float) -> void:
+	self.scale = self.scale.lerp(target_scale, scale_speed * delta)
 
 func show_tooltip():
 	self.visible = true
-	scale = Vector2(1,1) / Vector2(cardDisplay.scale[0], cardDisplay.scale[1])
-
+	scale_speed = 20.0
+	target_scale = Vector2(1, 1) / Vector2(cardDisplay.scale[0], cardDisplay.scale[1])
 
 func hide_tooltip():
-	self.visible = false
+	target_scale = Vector2(0, 0)
+	scale_speed = 20.0
+	# await get_tree().create_timer(0.3).timeout
+	# self.visible = false

--- a/scripts/Cards/Classes/card_tooltip.gd
+++ b/scripts/Cards/Classes/card_tooltip.gd
@@ -13,14 +13,41 @@ func _ready() -> void:
 	self.scale = Vector2(0, 0)  # Start hidden
 	name_label.text = str(cardDisplay.card.card_name)
 	damage_label.text = str(cardDisplay.card.damage, " dmg")
+	adjust_position()
+
 
 func _process(delta: float) -> void:
 	self.scale = self.scale.lerp(target_scale, scale_speed * delta)
 
 func show_tooltip():
+	adjust_position()
 	self.visible = true
 	scale_speed = 20.0
 	target_scale = Vector2(1, 1) / Vector2(cardDisplay.scale[0], cardDisplay.scale[1])
+
+
+func adjust_position():
+	var viewport_size = get_viewport().size
+	var margin = 5
+	var area_global_position = $Card/Area2D.global_position
+	var area_size = $Card/Area2D.get_node("CollisionShape2D").shape.extents * 2
+
+	# Calculate the edges of the tooltip
+	var left_edge = area_global_position.x
+	var right_edge = area_global_position.x + area_size.x
+	var top_edge = area_global_position.y - (area_size.y/2)
+	var bottom_edge = area_global_position.y + (area_size.y/2)
+
+	# Adjust position to ensure the tooltip stays within the viewport
+	if left_edge < margin:
+		self.position.x += margin - left_edge
+	elif right_edge > viewport_size.x - margin:
+		self.position.x -= right_edge - (viewport_size.x - margin)
+
+	if top_edge < margin:
+		self.position.y = margin + area_size.y/4
+	elif bottom_edge > viewport_size.y - margin:
+		self.position.y -= bottom_edge - (viewport_size.y - margin)
 
 func hide_tooltip():
 	target_scale = Vector2(0, 0)

--- a/scripts/Cards/Classes/card_tooltip.gd
+++ b/scripts/Cards/Classes/card_tooltip.gd
@@ -4,8 +4,15 @@ extends Node2D
 var target_scale = Vector2(0, 0)
 var scale_speed = 20.0
 
+
+@onready var damage_label = $Card/Damage
+@onready var name_label = $Card/Name
+
+
 func _ready() -> void:
 	self.scale = Vector2(0, 0)  # Start hidden
+	name_label.text = str(cardDisplay.card.card_name)
+	damage_label.text = str(cardDisplay.card.damage, " dmg")
 
 func _process(delta: float) -> void:
 	self.scale = self.scale.lerp(target_scale, scale_speed * delta)

--- a/scripts/CombatScripts/planning.gd
+++ b/scripts/CombatScripts/planning.gd
@@ -55,6 +55,7 @@ func display_deck():
 		card_display.card = player.active_deck[i]
 		card_display.scale = Vector2(0.66, 0.66)
 		card_display.position = Vector2((i % 5 - 2) * 25, int(i / 5) * 35)
+		card_display.hoverable = true
 		card_display.connect("card_clicked", Callable(self, "_on_card_clicked"))
 		card_display.add_to_group("CardDisplays")
 		active_deck_object.add_child(card_display)
@@ -67,10 +68,10 @@ func display_prepared_hand():
 		card_display.card = selected_cards[i]
 		card_display.position = Vector2((i - (selected_cards.size() - 1) / 2.0) * 30, 0)
 		card_display.scale = Vector2(0.78, 0.78)
+		card_display.hoverable = true
 		card_display.connect("card_clicked", Callable(self, "_on_card_clicked"))
 		card_display.add_to_group("CardDisplays")
 		prepared_hand_object.add_child(card_display)
-		#adjust_hitbox(card_display, i == selected_cards.size() - 1)
 
 func _on_card_clicked(card, parent_node):
 	if parent_node.name == "Active Deck":


### PR DESCRIPTION
This updates the card hovers to show a blown-up version of the card, showing it's name and damage.

![image](https://github.com/user-attachments/assets/625c9f4f-e7ba-4394-b855-3fc794c191a8)

This resolves #47 