### PR TITLE
Adds input lock to prevent unintended actions

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -19,6 +19,7 @@ config/icon="res://icon.svg"
 
 Events="*res://scripts/events.gd"
 DOT="*res://scripts/CombatScripts/status_manager.gd"
+InputLock="*res://scripts/input_lock.gd"
 
 [display]
 

--- a/scenes/Screens/Combat/CardSelectionPhase.tscn
+++ b/scenes/Screens/Combat/CardSelectionPhase.tscn
@@ -1,0 +1,18 @@
+[gd_scene load_steps=3 format=3 uid="uid://d4g07fx3gvsh6"]
+
+[ext_resource type="Script" path="res://scripts/CombatScripts/card_selection_phase.gd" id="1_script"]
+[ext_resource type="Texture2D" uid="uid://brmqxf3lpcklu" path="res://assets/Combat/Battle Panels.png" id="2_6mnuh"]
+
+[node name="CardSelectionPhase" type="Control"]
+layout_mode = 3
+anchors_preset = 0
+script = ExtResource("1_script")
+
+[node name="CardContainer" type="Node2D" parent="."]
+z_index = 10
+position = Vector2(136, 85)
+
+[node name="BattlePanels" type="Sprite2D" parent="."]
+z_index = -1
+texture = ExtResource("2_6mnuh")
+centered = false

--- a/scenes/Screens/Combat/Combat.tscn
+++ b/scenes/Screens/Combat/Combat.tscn
@@ -1,8 +1,8 @@
 [gd_scene load_steps=6 format=3 uid="uid://bl83ryin8usen"]
 
 [ext_resource type="Script" path="res://scripts/CombatScripts/combat.gd" id="1_arqx6"]
-[ext_resource type="PackedScene" uid="uid://duk30r0o83e5r" path="res://scenes/screens/Combat/Planning_Phase.tscn" id="2_mdd02"]
-[ext_resource type="PackedScene" uid="uid://bfw14idsdji" path="res://scenes/screens/Combat/Attack_Phase.tscn" id="3_k7e02"]
+[ext_resource type="PackedScene" uid="uid://duk30r0o83e5r" path="res://scenes/screens/combat/Planning_Phase.tscn" id="2_mdd02"]
+[ext_resource type="PackedScene" uid="uid://bfw14idsdji" path="res://scenes/screens/combat/Attack_Phase.tscn" id="3_k7e02"]
 [ext_resource type="Script" path="res://scripts/CombatScripts/enemy.gd" id="4_d73mv"]
 [ext_resource type="PackedScene" uid="uid://secgp8pnl7r4" path="res://scenes/assets/Combat/ReadyButton.tscn" id="5_0hpti"]
 

--- a/scripts/ClinicScripts/clinic.gd
+++ b/scripts/ClinicScripts/clinic.gd
@@ -30,22 +30,24 @@ func _transition_to_health_shop():
 	self.add_child(health_shop_instance)
 
 func _transition_from_health_shop():
+	InputLock._lock_scene_input()
 	health_shop_instance.queue_free()
 	clinic_menu.visible = true
 
 func _transition_to_card_shop():
+	InputLock._lock_scene_input()
 	card_shop_instance.visible = true
 	player.prepare_deck()
 	card_shop_instance._display_player_deck()
 	clinic_menu.visible = false
 	
 func _transition_from_card_shop():
+	InputLock._lock_scene_input()
 	card_shop_instance.visible = false
 	clinic_menu.visible = true
 	
 func _transition_to_navigation():
+	InputLock._lock_scene_input()
 	navigation.visible = true
 	Events._navigation_focus.emit(true, true)
 	self.queue_free()
-	
-	

--- a/scripts/NavigationScripts/navigation.gd
+++ b/scripts/NavigationScripts/navigation.gd
@@ -330,11 +330,13 @@ func _transition_to_encounter(node: Node2D):
 	var node_type = node.node_type
 	match node_type:
 		NodeType.COMBAT:
+			InputLock._lock_scene_input()
 			print("Transitioning to combat")
 			var combat_scene = load("res://scenes/screens/Combat/Combat.tscn").instantiate()
 			get_tree().root.get_node("Main").add_child(combat_scene)  # Add to "Main" under root
 			player.copy_deck()
 		NodeType.CLINIC:
+			InputLock._lock_scene_input()
 			print("Transitioning to clinic")
 			var clinic_scene = load("res://scenes/screens/Clinic/Clinic.tscn").instantiate()
 			get_tree().root.get_node("Main").add_child(clinic_scene)  # Add to "Main" under root

--- a/scripts/ShopScripts/shop.gd
+++ b/scripts/ShopScripts/shop.gd
@@ -92,6 +92,7 @@ func _create_back_button():
 	button.connect("pressed", Callable(self, "_on_back_button_pressed"))
 
 func _on_back_button_pressed():
+	InputLock._lock_scene_input()
 	var navigation_scene = get_parent().get_node("Navigation")
 	var npc_ui = navigation_scene.get_parent().get_node("Ui").get_node("EnemyUi")
 	

--- a/scripts/input_lock.gd
+++ b/scripts/input_lock.gd
@@ -1,0 +1,18 @@
+extends Node
+
+var input_locked = false
+var lock_duration = 10
+
+func lock_input(duration: float) -> void:
+	input_locked = true
+	await get_tree().create_timer(duration).timeout
+	input_locked = false
+	
+func is_input_locked() -> bool:
+	return input_locked
+
+func _lock_scene_input() -> void:
+	if input_locked:
+		return
+	lock_input(lock_duration)
+


### PR DESCRIPTION
Implements an input lock mechanism to prevent multiple transitions from occurring simultaneously.

This addresses the issue where rapidly clicking on navigation nodes or shop buttons could trigger multiple scene transitions, leading to unexpected behavior.

Adds an `InputLock` singleton that manages a global input lock. This lock is activated during scene transitions, shop interactions, and other critical actions to prevent the user from inadvertently triggering multiple actions at once.